### PR TITLE
purge_local: delete UserAccounts

### DIFF
--- a/pinax/stripe/actions/customers.py
+++ b/pinax/stripe/actions/customers.py
@@ -140,6 +140,7 @@ def get_customer_for_user(user, stripe_account=None):
 
 
 def purge_local(customer):
+    customer.users.all().delete()
     customer.user = None
     customer.date_purged = timezone.now()
     customer.save()


### PR DESCRIPTION
This is required for us to remove the customer when it gets deleted via the dashboard.