### PR TITLE
next: actions.subscriptions.cancel: skip GET

### DIFF
--- a/pinax/stripe/actions/subscriptions.py
+++ b/pinax/stripe/actions/subscriptions.py
@@ -17,7 +17,12 @@ def cancel(subscription, at_period_end=True):
         subscription: the subscription to cancel
         at_period_end: True to cancel at the end of the period, otherwise cancels immediately
     """
-    sub = subscription.stripe_subscription.delete(at_period_end=at_period_end)
+    sub = stripe.Subscription(
+        subscription.stripe_id,
+        stripe_account=subscription.stripe_account,
+    ).delete(
+        at_period_end=at_period_end,
+    )
     return sync_subscription_from_stripe_data(subscription.customer, sub)
 
 

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -995,14 +995,25 @@ class SubscriptionsTests(TestCase):
         )
         self.assertTrue(subscriptions.has_active_subscription(self.customer))
 
+    @patch("stripe.Subscription")
     @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
-    def test_cancel_subscription(self, SyncMock):
-        SubMock = Mock()
+    def test_cancel_subscription(self, SyncMock, StripeSubMock):
+        subscription = Subscription(stripe_id="sub_X", customer=self.customer)
         obj = object()
         SyncMock.return_value = obj
-        sub = subscriptions.cancel(SubMock)
+        sub = subscriptions.cancel(subscription)
         self.assertIs(sub, obj)
         self.assertTrue(SyncMock.called)
+        _, kwargs = StripeSubMock.call_args
+        self.assertEquals(kwargs["stripe_account"], None)
+
+    @patch("stripe.Subscription")
+    @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
+    def test_cancel_subscription_with_account(self, SyncMock, StripeSubMock):
+        subscription = Subscription(stripe_id="sub_X", customer=self.connected_customer)
+        subscriptions.cancel(subscription)
+        _, kwargs = StripeSubMock.call_args
+        self.assertEquals(kwargs["stripe_account"], self.account)
 
     @patch("pinax.stripe.actions.subscriptions.sync_subscription_from_stripe_data")
     def test_update(self, SyncMock):


### PR DESCRIPTION
Skip retrieving the Stripe subscription object when deleting it.